### PR TITLE
update link to README in header

### DIFF
--- a/scaffolds/nextjs-dedicated-wallet/template/src/components/ui/Header.tsx
+++ b/scaffolds/nextjs-dedicated-wallet/template/src/components/ui/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
         </div>
       </div>
       <DevLinks />
-      <p className="text-sm font-semibold text-white">Take a look at our <a href="https://github.com/magiclabs/create-magic-app" target='_blank' className="cursor-pointer text-[#6851ff]">developer guide</a> to learn more about this template</p>
+      <p className="text-sm font-semibold text-white">Take a look at our <a href="https://github.com/magiclabs/create-magic-app/blob/master/scaffolds/nextjs-dedicated-wallet/template/README.md" target='_blank' className="cursor-pointer text-[#6851ff]">developer guide</a> to learn more about this template</p>
     </div>
   );
 };


### PR DESCRIPTION
### 📦 Pull Request

The link in the nextjs EVM template header points to the root page for `create-magic-app`. This updates the template header link to point to the template README with all of the correct architecture information.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix
